### PR TITLE
Install the dependencies before copying the code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/Dockerfile
+**/docker-compose.*.yml
+**/docker-compose.yml
+.dockerignore
+.git
+**/.gitignore
+README.md
+vendor/
+.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,16 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY --chown=root:root docker/php/php.ini /usr/local/etc/php/php.ini
 COPY --chown=root:root docker/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
-COPY --chown=www-data:www-data . /app
 
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 WORKDIR /app
 
+COPY --chown=www-data:www-data composer.json composer.lock /app/
 RUN composer install --no-interaction --no-ansi -o
+
+COPY --chown=www-data:www-data . /app
 
 #
 # Build dev stuff


### PR DESCRIPTION
Any code change had triggered "composer install" to deploy all the dependencies even if they did not change.
This PR makes use of docker layer caching to speed up the build with unchanged dependenices.
Also it excludes some docker- and git-specific files from the resulting image.